### PR TITLE
Add croak_sv

### DIFF
--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -166,6 +166,15 @@ __UNDEFINED__  AvFILLp      AvFILL
 
 __UNDEFINED__  ERRSV        get_sv("@",FALSE)
 
+#if { VERSION < 5.13.1 }
+#  undef croak_sv
+#  define croak_sv(sv)                \
+      STMT_START {                    \
+            sv_setsv(ERRSV, sv);      \
+            Perl_croak(aTHX_ Nullch); \
+      } STMT_END
+#endif
+
 /* Hint: gv_stashpvn
  * This function's backport doesn't support the length parameter, but
  * rather ignores it. Portability can only be ensured if the length

--- a/parts/todo/5013001
+++ b/parts/todo/5013001
@@ -1,5 +1,4 @@
 5.013001
-croak_sv                       # U
 die_sv                         # U
 mess_sv                        # U
 sv_2nv_flags                   # U


### PR DESCRIPTION
This PR (tries) to add support for `croak_sv`. Not sure if this is the correct place to put it and/or the tests that are required (or how to write them). Verified that it does work for perl 5.10 and 5.12, see:

https://travis-ci.org/ghedo/p5-Git-Raw/builds/25368088
https://github.com/ghedo/p5-Git-Raw/compare/4286a050708d...57d263003b81
