### PR TITLE
Sort the list of XS code files when generating RealPPPort.xs

### DIFF
--- a/PPPort_xs.PL
+++ b/PPPort_xs.PL
@@ -38,7 +38,7 @@ END
 my $file;
 my $sec;
 
-for $file (all_files_in_dir('parts/inc')) {
+for $file (sort(all_files_in_dir('parts/inc'))) {
   my $spec = parse_partspec($file);
 
   my $msg = 0;


### PR DESCRIPTION
all_files_in_dir() uses readdir() ordering to make the list of
input files. This can vary between build systems, breaking build
reproducibility.

Bug-Debian: https://bugs.debian.org/801523