### PR TITLE
Fix gv_fetchpvn_flags and add gv_init_pvn

### DIFF
--- a/parts/inc/gv
+++ b/parts/inc/gv
@@ -11,16 +11,34 @@
 
 =provides
 
+gv_fetchpvn_flags
 __UNDEFINED__
 
 =implementation
 
+#ifndef gv_fetchpvn_flags
+#if { NEED gv_fetchpvn_flags }
+
+GV* 
+gv_fetchpvn_flags(pTHX_ const char* name, STRLEN len, int flags, int types) {
+	char *namepv = savepvn(name, len);
+	GV* stash = gv_fetchpv(namepv, TRUE, SVt_PVHV);
+	Safefree(namepv);
+	return stash;
+}
+
+#endif
+#endif
+
 __UNDEFINED__ GvSVn(gv)        GvSV(gv)
 __UNDEFINED__ isGV_with_GP(gv) isGV(gv)
-__UNDEFINED__ gv_fetchpvn_flags(name, len, flags, svt) gv_fetchpv(name, flags, svt)
 __UNDEFINED__ gv_fetchsv(name, flags, svt) gv_fetchpv(SvPV_nolen_const(name), flags, svt)
 
 __UNDEFINED__ get_cvn_flags(name, namelen, flags) get_cv(name, flags)
+
+=xsinit
+
+#define NEED_gv_fetchpvn_flags
 
 =xsubs
 

--- a/parts/inc/gv
+++ b/parts/inc/gv
@@ -35,6 +35,7 @@ __UNDEFINED__ isGV_with_GP(gv) isGV(gv)
 __UNDEFINED__ gv_fetchsv(name, flags, svt) gv_fetchpv(SvPV_nolen_const(name), flags, svt)
 
 __UNDEFINED__ get_cvn_flags(name, namelen, flags) get_cv(name, flags)
+__UNDEFINED__ gv_init_pvn(gv, stash, ptr, len, flags) gv_init(gv, stash, ptr, len, flags & GV_ADDMULTI ? TRUE : FALSE)
 
 =xsinit
 

--- a/parts/todo/5015004
+++ b/parts/todo/5015004
@@ -16,7 +16,6 @@ gv_fetchmethod_pv_flags        # U
 gv_fetchmethod_pvn_flags       # U
 gv_fetchmethod_sv_flags        # U
 gv_init_pv                     # U
-gv_init_pvn                    # U
 gv_init_sv                     # U
 newGVgen_flags                 # U
 sv_derived_from_pv             # U


### PR DESCRIPTION
This changes `gv_fetchpvn_flags` from a macro tan actual function. The old definition could give incorrect results when the name argument was a partial C string. This is not entirely backwards compatible.

It also adds `gv_init_pvn`