### PR TITLE
Fix crash in function eval_pv()

### DIFF
--- a/parts/inc/call
+++ b/parts/inc/call
@@ -70,7 +70,7 @@ eval_pv(char *p, I32 croak_on_error)
     PUTBACK;
 
     if (croak_on_error && SvTRUE(GvSV(errgv)))
-        croak(SvPVx(GvSV(errgv), na));
+        croak("%s", SvPVx(GvSV(errgv), na));
 
     return sv;
 }


### PR DESCRIPTION
Function croak() takes first parameter printf-like format. Arbitrary string
from the variable $@ can cause perl crash when contains one or more '%'.